### PR TITLE
Use in-process hosting for IIS Express

### DIFF
--- a/src/TodoApp/Properties/launchSettings.json
+++ b/src/TodoApp/Properties/launchSettings.json
@@ -10,6 +10,7 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
+      "ancmHostingModel": "InProcess",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
Enable in-process hosting when using IIS Express for debugging locally.
