### PR TITLE
Get version from global.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
 
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.301
 
     - name: Build, Test and Publish
       shell: pwsh


### PR DESCRIPTION
Get the version of the .NET Core SDK to use from `global.json`.
