### PR TITLE
Remove SetCompatibilityVersion()

### DIFF
--- a/src/TodoApp/Startup.cs
+++ b/src/TodoApp/Startup.cs
@@ -39,8 +39,7 @@ namespace TodoApp
             services.AddLocalization();
 
             services.AddMvc()
-                    .AddViewLocalization()
-                    .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+                    .AddViewLocalization();
 
             services.AddDbContext<TodoContext>((builder) => builder.UseInMemoryDatabase(databaseName: "TodoApp"));
         }


### PR DESCRIPTION
Remove call to `SetCompatibilityVersion()` that is no longer needed and is obsolete in .NET 6 (see #129).
