### PR TITLE
Bump Microsoft.DotNet.XliffTasks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21452.1" />
+    <PackageVersion Include="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="PseudoLocalizer.Humanizer" Version="0.9.1" />


### PR DESCRIPTION
Bump to the latest 1.0.0 release of Microsoft.DotNet.XliffTasks.
